### PR TITLE
Replace jcenter() with mavenCentral()

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     ext.kotlin_version = '1.3.72'
     repositories {
         google()
-        jcenter()
+        mavenCentral()
         
     }
     dependencies {
@@ -19,7 +19,7 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
         
     }
 }


### PR DESCRIPTION
Fixes #2 
In anticipation of jcenter shutting down, I replaced jcenter() with mavenCentral().

I tested that the app built and deployed to a google pixel 4a and consumed it's spp services.